### PR TITLE
POC encoding/json.IndentWriter implementation

### DIFF
--- a/src/encoding/json/indent.go
+++ b/src/encoding/json/indent.go
@@ -4,7 +4,10 @@
 
 package json
 
-import "bytes"
+import (
+	"bytes"
+	"io"
+)
 
 // Compact appends to dst the JSON-encoded src with
 // insignificant space characters elided.
@@ -60,7 +63,7 @@ func compact(dst *bytes.Buffer, src []byte, escape bool) error {
 	return nil
 }
 
-func newline(dst *bytes.Buffer, prefix, indent string, depth int) {
+func newline(dst writer, prefix, indent string, depth int) {
 	dst.WriteByte('\n')
 	dst.WriteString(prefix)
 	for i := 0; i < depth; i++ {
@@ -83,27 +86,68 @@ func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 	origLen := dst.Len()
 	var scan scanner
 	scan.reset()
-	needIndent := false
-	depth := 0
+	w := &indentWriter{
+		dst:    dst,
+		prefix: prefix,
+		indent: indent,
+		scan:   &scan,
+	}
+	if _, err := w.Write(src); err != nil {
+		dst.Truncate(origLen)
+		return err
+	}
+	return nil
+}
+
+// IndentWriter wraps w, re-indenting the data written to it, according to
+// prefix and indent. If any parsing error occurs, it will be returned on the
+// next call to Write() on the returned io.Writer.
+func IndentWriter(w io.Writer, prefix, indent string) io.Writer {
+	dst, ok := w.(writer)
+	if !ok {
+		dst = &convertWriter{w}
+	}
+	var scan scanner
+	scan.reset()
+	return &indentWriter{
+		dst:    dst,
+		prefix: prefix,
+		indent: indent,
+		scan:   &scan,
+	}
+}
+
+type indentWriter struct {
+	dst        writer
+	prefix     string
+	indent     string
+	depth      int
+	scan       *scanner
+	needIndent bool
+}
+
+func (w *indentWriter) Write(src []byte) (int, error) {
+	var n int
 	for _, c := range src {
-		scan.bytes++
-		v := scan.step(&scan, c)
+		n++
+		w.scan.bytes++
+		v := w.scan.step(w.scan, c)
 		if v == scanSkipSpace {
 			continue
 		}
 		if v == scanError {
 			break
 		}
-		if needIndent && v != scanEndObject && v != scanEndArray {
-			needIndent = false
-			depth++
-			newline(dst, prefix, indent, depth)
+		if w.needIndent && v != scanEndObject && v != scanEndArray {
+			w.needIndent = false
+			w.depth++
+			newline(w.dst, w.prefix, w.indent, w.depth)
 		}
 
 		// Emit semantically uninteresting bytes
 		// (in particular, punctuation in strings) unmodified.
 		if v == scanContinue {
-			dst.WriteByte(c)
+			w.dst.WriteByte(c)
 			continue
 		}
 
@@ -111,34 +155,33 @@ func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 		switch c {
 		case '{', '[':
 			// delay indent so that empty object and array are formatted as {} and [].
-			needIndent = true
-			dst.WriteByte(c)
+			w.needIndent = true
+			w.dst.WriteByte(c)
 
 		case ',':
-			dst.WriteByte(c)
-			newline(dst, prefix, indent, depth)
+			w.dst.WriteByte(c)
+			newline(w.dst, w.prefix, w.indent, w.depth)
 
 		case ':':
-			dst.WriteByte(c)
-			dst.WriteByte(' ')
+			w.dst.WriteByte(c)
+			w.dst.WriteByte(' ')
 
 		case '}', ']':
-			if needIndent {
+			if w.needIndent {
 				// suppress indent in empty object/array
-				needIndent = false
+				w.needIndent = false
 			} else {
-				depth--
-				newline(dst, prefix, indent, depth)
+				w.depth--
+				newline(w.dst, w.prefix, w.indent, w.depth)
 			}
-			dst.WriteByte(c)
+			w.dst.WriteByte(c)
 
 		default:
-			dst.WriteByte(c)
+			w.dst.WriteByte(c)
 		}
 	}
-	if scan.eof() == scanError {
-		dst.Truncate(origLen)
-		return scan.err
+	if w.scan.eof() == scanError {
+		return n, w.scan.err
 	}
-	return nil
+	return n, nil
 }

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -6,6 +6,7 @@ package json
 
 import (
 	"bytes"
+	"io"
 	"math"
 	"math/rand"
 	"reflect"
@@ -124,6 +125,29 @@ func BenchmarkIndentExample7b(b *testing.B) {
 	benchmarkIndent(strings.Repeat(examples[6].compact, 100), b)
 }
 
+func benchmarkIndentStream(in string, b *testing.B) {
+	b.ReportAllocs()
+	b.SetBytes(int64(len(in)))
+	var buf bytes.Buffer
+	r := &strings.Reader{}
+	for n := 0; n < b.N; n++ {
+		buf.Reset()
+		r.Reset(in)
+		_, _ = io.Copy(IndentWriter(&buf, "", "\t"), r)
+	}
+}
+
+func BenchmarkIndentStreamExample1(b *testing.B) { benchmarkIndentStream(examples[0].compact, b) }
+func BenchmarkIndentStreamExample2(b *testing.B) { benchmarkIndentStream(examples[1].compact, b) }
+func BenchmarkIndentStreamExample3(b *testing.B) { benchmarkIndentStream(examples[2].compact, b) }
+func BenchmarkIndentStreamExample4(b *testing.B) { benchmarkIndentStream(examples[3].compact, b) }
+func BenchmarkIndentStreamExample5(b *testing.B) { benchmarkIndentStream(examples[4].compact, b) }
+func BenchmarkIndentStreamExample6(b *testing.B) { benchmarkIndentStream(examples[5].compact, b) }
+func BenchmarkIndentStreamExample7(b *testing.B) { benchmarkIndentStream(examples[6].compact, b) }
+func BenchmarkIndentStreamExample7b(b *testing.B) {
+	benchmarkIndentStream(strings.Repeat(examples[6].compact, 100), b)
+}
+
 func TestIndent(t *testing.T) {
 	var buf bytes.Buffer
 	for _, tt := range examples {
@@ -142,6 +166,39 @@ func TestIndent(t *testing.T) {
 			t.Errorf("Indent(%#q) = %#q, want %#q", tt.compact, s, tt.indent)
 		}
 	}
+}
+
+func TestStreamIndent(t *testing.T) {
+	var buf bytes.Buffer
+	for _, tt := range examples {
+		buf.Reset()
+		w := IndentWriter(&buf, "", "\t")
+		_, err := io.Copy(w, strings.NewReader(tt.indent))
+		if err != nil {
+			t.Errorf("Indent(%#q): %v", tt.indent, err)
+		} else if s := buf.String(); s != tt.indent {
+			t.Errorf("Indent(%#q) = %#q, want original", tt.indent, s)
+		}
+
+		buf.Reset()
+		w = IndentWriter(&buf, "", "\t")
+		_, err = io.Copy(w, strings.NewReader(tt.compact))
+		if err != nil {
+			t.Errorf("Indent(%#q): %v", tt.compact, err)
+			continue
+		} else if s := buf.String(); s != tt.indent {
+			t.Errorf("Indent(%#q) = %#q, want %#q", tt.compact, s, tt.indent)
+		}
+	}
+
+	t.Run("malformed input", func(t *testing.T) {
+		buf.Reset()
+		w := IndentWriter(&buf, "", "\t")
+		_, err := io.Copy(w, strings.NewReader("bogus json"))
+		if err == nil {
+			t.Error("Expected error, got success")
+		}
+	})
 }
 
 // Tests of a large random structure.

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -100,6 +101,27 @@ func TestCompactSeparators(t *testing.T) {
 			t.Errorf("Compact(%q) = %q, want %q", tt.in, s, tt.compact)
 		}
 	}
+}
+
+func benchmarkIndent(in string, b *testing.B) {
+	b.ReportAllocs()
+	b.SetBytes(int64(len(in)))
+	var buf bytes.Buffer
+	for n := 0; n < b.N; n++ {
+		buf.Reset()
+		_ = Indent(&buf, []byte(in), "", "\t")
+	}
+}
+
+func BenchmarkIndentExample1(b *testing.B) { benchmarkIndent(examples[0].compact, b) }
+func BenchmarkIndentExample2(b *testing.B) { benchmarkIndent(examples[1].compact, b) }
+func BenchmarkIndentExample3(b *testing.B) { benchmarkIndent(examples[2].compact, b) }
+func BenchmarkIndentExample4(b *testing.B) { benchmarkIndent(examples[3].compact, b) }
+func BenchmarkIndentExample5(b *testing.B) { benchmarkIndent(examples[4].compact, b) }
+func BenchmarkIndentExample6(b *testing.B) { benchmarkIndent(examples[5].compact, b) }
+func BenchmarkIndentExample7(b *testing.B) { benchmarkIndent(examples[6].compact, b) }
+func BenchmarkIndentExample7b(b *testing.B) {
+	benchmarkIndent(strings.Repeat(examples[6].compact, 100), b)
 }
 
 func TestIndent(t *testing.T) {

--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -505,3 +505,21 @@ func (dec *Decoder) peek() (byte, error) {
 func (dec *Decoder) offset() int64 {
 	return dec.scanned + int64(dec.scanp)
 }
+
+type writer interface {
+	Write([]byte) (int, error)
+	WriteString(string) (int, error)
+	WriteByte(byte) error
+}
+
+type convertWriter struct {
+	io.Writer
+}
+
+func (c convertWriter) WriteString(s string) (int, error) {
+	return io.WriteString(c, s)
+}
+func (c convertWriter) WriteByte(b byte) error {
+	_, err := c.Write([]byte{b})
+	return err
+}


### PR DESCRIPTION
This adds some Benchmarks for the existing `Indent` function, against the existing indent test inputs. A typical run:

```
BenchmarkIndentExample1-2       20000000               116 ns/op           8.56 MB/s          64 B/op          1 allocs/op
BenchmarkIndentExample2-2       10000000               194 ns/op          10.30 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample3-2       10000000               180 ns/op          11.10 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample4-2        5000000               323 ns/op          18.56 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample5-2       10000000               261 ns/op          11.49 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample6-2        5000000               365 ns/op          19.13 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample7-2        5000000               321 ns/op          21.76 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample7b-2       1000000              1004 ns/op         696.72 MB/s         880 B/op          8 allocs/op
```

Then it adds streaming support, and adds a new exported method, `IndentWriter`, which wraps an `io.Writer`, and indents the stream, as documented. Benchmark results virtually identical (within expected bounds for running tests on a VM), with the addition of a new set of tests for the streaming functionality:

```
BenchmarkIndentExample1-2               10000000               139 ns/op           7.19 MB/s          64 B/op          1 allocs/op
BenchmarkIndentExample2-2               10000000               189 ns/op          10.58 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample3-2               10000000               204 ns/op           9.79 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample4-2                5000000               330 ns/op          18.18 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample5-2                5000000               276 ns/op          10.84 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample6-2                3000000               409 ns/op          17.09 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample7-2                5000000               342 ns/op          20.42 MB/s          72 B/op          2 allocs/op
BenchmarkIndentExample7b-2               1000000              1165 ns/op         600.74 MB/s         880 B/op          8 allocs/op
BenchmarkIndentStreamExample1-2          5000000               323 ns/op           3.09 MB/s         152 B/op          3 allocs/op
BenchmarkIndentStreamExample2-2          5000000               367 ns/op           5.44 MB/s         160 B/op          4 allocs/op
BenchmarkIndentStreamExample3-2          5000000               363 ns/op           5.50 MB/s         160 B/op          4 allocs/op
BenchmarkIndentStreamExample4-2          3000000               496 ns/op          12.08 MB/s         160 B/op          4 allocs/op
BenchmarkIndentStreamExample5-2          3000000               455 ns/op           6.58 MB/s         160 B/op          4 allocs/op
BenchmarkIndentStreamExample6-2          3000000               640 ns/op          10.94 MB/s         160 B/op          4 allocs/op
BenchmarkIndentStreamExample7-2          3000000               520 ns/op          13.45 MB/s         160 B/op          4 allocs/op
BenchmarkIndentStreamExample7b-2         1000000              1293 ns/op         541.27 MB/s         960 B/op          9 allocs/op
```