### PR TITLE
POC: encoder.Encode() using IndentWriter

### DIFF
--- a/src/encoding/json/indent.go
+++ b/src/encoding/json/indent.go
@@ -4,7 +4,10 @@
 
 package json
 
-import "bytes"
+import (
+	"bytes"
+	"io"
+)
 
 // Compact appends to dst the JSON-encoded src with
 // insignificant space characters elided.
@@ -60,7 +63,7 @@ func compact(dst *bytes.Buffer, src []byte, escape bool) error {
 	return nil
 }
 
-func newline(dst *bytes.Buffer, prefix, indent string, depth int) {
+func newline(dst writer, prefix, indent string, depth int) {
 	dst.WriteByte('\n')
 	dst.WriteString(prefix)
 	for i := 0; i < depth; i++ {
@@ -83,27 +86,68 @@ func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 	origLen := dst.Len()
 	var scan scanner
 	scan.reset()
-	needIndent := false
-	depth := 0
+	w := &indentWriter{
+		dst:    dst,
+		prefix: prefix,
+		indent: indent,
+		scan:   &scan,
+	}
+	if _, err := w.Write(src); err != nil {
+		dst.Truncate(origLen)
+		return err
+	}
+	return nil
+}
+
+// IndentWriter wraps w, re-indenting the data written to it, according to
+// prefix and indent. If any parsing error occurs, it will be returned on the
+// next call to Write() on the returned io.Writer.
+func IndentWriter(w io.Writer, prefix, indent string) io.Writer {
+	dst, ok := w.(writer)
+	if !ok {
+		dst = &convertWriter{w}
+	}
+	var scan scanner
+	scan.reset()
+	return &indentWriter{
+		dst:    dst,
+		prefix: prefix,
+		indent: indent,
+		scan:   &scan,
+	}
+}
+
+type indentWriter struct {
+	dst        writer
+	prefix     string
+	indent     string
+	depth      int
+	scan       *scanner
+	needIndent bool
+}
+
+func (w *indentWriter) Write(src []byte) (int, error) {
+	var n int
 	for _, c := range src {
-		scan.bytes++
-		v := scan.step(&scan, c)
+		n++
+		w.scan.bytes++
+		v := w.scan.step(w.scan, c)
 		if v == scanSkipSpace {
 			continue
 		}
 		if v == scanError {
 			break
 		}
-		if needIndent && v != scanEndObject && v != scanEndArray {
-			needIndent = false
-			depth++
-			newline(dst, prefix, indent, depth)
+		if w.needIndent && v != scanEndObject && v != scanEndArray {
+			w.needIndent = false
+			w.depth++
+			newline(w.dst, w.prefix, w.indent, w.depth)
 		}
 
 		// Emit semantically uninteresting bytes
 		// (in particular, punctuation in strings) unmodified.
 		if v == scanContinue {
-			dst.WriteByte(c)
+			w.dst.WriteByte(c)
 			continue
 		}
 
@@ -111,34 +155,33 @@ func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
 		switch c {
 		case '{', '[':
 			// delay indent so that empty object and array are formatted as {} and [].
-			needIndent = true
-			dst.WriteByte(c)
+			w.needIndent = true
+			w.dst.WriteByte(c)
 
 		case ',':
-			dst.WriteByte(c)
-			newline(dst, prefix, indent, depth)
+			w.dst.WriteByte(c)
+			newline(w.dst, w.prefix, w.indent, w.depth)
 
 		case ':':
-			dst.WriteByte(c)
-			dst.WriteByte(' ')
+			w.dst.WriteByte(c)
+			w.dst.WriteByte(' ')
 
 		case '}', ']':
-			if needIndent {
+			if w.needIndent {
 				// suppress indent in empty object/array
-				needIndent = false
+				w.needIndent = false
 			} else {
-				depth--
-				newline(dst, prefix, indent, depth)
+				w.depth--
+				newline(w.dst, w.prefix, w.indent, w.depth)
 			}
-			dst.WriteByte(c)
+			w.dst.WriteByte(c)
 
 		default:
-			dst.WriteByte(c)
+			w.dst.WriteByte(c)
 		}
 	}
-	if scan.eof() == scanError {
-		dst.Truncate(origLen)
-		return scan.err
+	if w.scan.eof() == scanError {
+		return n, w.scan.err
 	}
-	return nil
+	return n, nil
 }

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -148,6 +148,27 @@ func BenchmarkIndentStreamExample7b(b *testing.B) {
 	benchmarkIndentStream(strings.Repeat(examples[6].compact, 100), b)
 }
 
+func benchmarkMarshalAndIndentStream(i interface{}, b *testing.B) {
+	b.ReportAllocs()
+	var buf bytes.Buffer
+	for n := 0; n < b.N; n++ {
+		buf.Reset()
+		enc := NewEncoder(&buf)
+		enc.SetIndent("", "\t")
+		_ = enc.Encode(i)
+	}
+}
+
+func BenchmarkMarshalAndIndentStream_Int(b *testing.B) {
+	benchmarkMarshalAndIndentStream(int(123), b)
+}
+func BenchmarkMarshalAndIndentStream_Optionals(b *testing.B) {
+	benchmarkMarshalAndIndentStream(&Optionals{}, b)
+}
+func BenchmarkMarshalAndIndentStream_StringTag(b *testing.B) {
+	benchmarkMarshalAndIndentStream(&StringTag{}, b)
+}
+
 func TestIndent(t *testing.T) {
 	var buf bytes.Buffer
 	for _, tt := range examples {

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -6,6 +6,7 @@ package json
 
 import (
 	"bytes"
+	"io"
 	"math"
 	"math/rand"
 	"reflect"
@@ -124,6 +125,29 @@ func BenchmarkIndentExample7b(b *testing.B) {
 	benchmarkIndent(strings.Repeat(examples[6].compact, 100), b)
 }
 
+func benchmarkIndentStream(in string, b *testing.B) {
+	b.ReportAllocs()
+	b.SetBytes(int64(len(in)))
+	var buf bytes.Buffer
+	r := &strings.Reader{}
+	for n := 0; n < b.N; n++ {
+		buf.Reset()
+		r.Reset(in)
+		_, _ = io.Copy(IndentWriter(&buf, "", "\t"), r)
+	}
+}
+
+func BenchmarkIndentStreamExample1(b *testing.B) { benchmarkIndentStream(examples[0].compact, b) }
+func BenchmarkIndentStreamExample2(b *testing.B) { benchmarkIndentStream(examples[1].compact, b) }
+func BenchmarkIndentStreamExample3(b *testing.B) { benchmarkIndentStream(examples[2].compact, b) }
+func BenchmarkIndentStreamExample4(b *testing.B) { benchmarkIndentStream(examples[3].compact, b) }
+func BenchmarkIndentStreamExample5(b *testing.B) { benchmarkIndentStream(examples[4].compact, b) }
+func BenchmarkIndentStreamExample6(b *testing.B) { benchmarkIndentStream(examples[5].compact, b) }
+func BenchmarkIndentStreamExample7(b *testing.B) { benchmarkIndentStream(examples[6].compact, b) }
+func BenchmarkIndentStreamExample7b(b *testing.B) {
+	benchmarkIndentStream(strings.Repeat(examples[6].compact, 100), b)
+}
+
 func TestIndent(t *testing.T) {
 	var buf bytes.Buffer
 	for _, tt := range examples {
@@ -142,6 +166,39 @@ func TestIndent(t *testing.T) {
 			t.Errorf("Indent(%#q) = %#q, want %#q", tt.compact, s, tt.indent)
 		}
 	}
+}
+
+func TestStreamIndent(t *testing.T) {
+	var buf bytes.Buffer
+	for _, tt := range examples {
+		buf.Reset()
+		w := IndentWriter(&buf, "", "\t")
+		_, err := io.Copy(w, strings.NewReader(tt.indent))
+		if err != nil {
+			t.Errorf("Indent(%#q): %v", tt.indent, err)
+		} else if s := buf.String(); s != tt.indent {
+			t.Errorf("Indent(%#q) = %#q, want original", tt.indent, s)
+		}
+
+		buf.Reset()
+		w = IndentWriter(&buf, "", "\t")
+		_, err = io.Copy(w, strings.NewReader(tt.compact))
+		if err != nil {
+			t.Errorf("Indent(%#q): %v", tt.compact, err)
+			continue
+		} else if s := buf.String(); s != tt.indent {
+			t.Errorf("Indent(%#q) = %#q, want %#q", tt.compact, s, tt.indent)
+		}
+	}
+
+	t.Run("malformed input", func(t *testing.T) {
+		buf.Reset()
+		w := IndentWriter(&buf, "", "\t")
+		_, err := io.Copy(w, strings.NewReader("bogus json"))
+		if err == nil {
+			t.Error("Expected error, got success")
+		}
+	})
 }
 
 // Tests of a large random structure.

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -154,6 +154,7 @@ func benchmarkMarshalAndIndentStream(i interface{}, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		buf.Reset()
 		enc := NewEncoder(&buf)
+		enc.SetDirectWrite()
 		enc.SetIndent("", "\t")
 		_ = enc.Encode(i)
 	}
@@ -301,6 +302,7 @@ func TestIndentErrors(t *testing.T) {
 }
 
 func diff(t *testing.T, a, b []byte) {
+	t.Helper()
 	for i := 0; ; i++ {
 		if i >= len(a) || i >= len(b) || a[i] != b[i] {
 			j := i - 10

--- a/src/encoding/json/scanner_test.go
+++ b/src/encoding/json/scanner_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -100,6 +101,27 @@ func TestCompactSeparators(t *testing.T) {
 			t.Errorf("Compact(%q) = %q, want %q", tt.in, s, tt.compact)
 		}
 	}
+}
+
+func benchmarkIndent(in string, b *testing.B) {
+	b.ReportAllocs()
+	b.SetBytes(int64(len(in)))
+	var buf bytes.Buffer
+	for n := 0; n < b.N; n++ {
+		buf.Reset()
+		_ = Indent(&buf, []byte(in), "", "\t")
+	}
+}
+
+func BenchmarkIndentExample1(b *testing.B) { benchmarkIndent(examples[0].compact, b) }
+func BenchmarkIndentExample2(b *testing.B) { benchmarkIndent(examples[1].compact, b) }
+func BenchmarkIndentExample3(b *testing.B) { benchmarkIndent(examples[2].compact, b) }
+func BenchmarkIndentExample4(b *testing.B) { benchmarkIndent(examples[3].compact, b) }
+func BenchmarkIndentExample5(b *testing.B) { benchmarkIndent(examples[4].compact, b) }
+func BenchmarkIndentExample6(b *testing.B) { benchmarkIndent(examples[5].compact, b) }
+func BenchmarkIndentExample7(b *testing.B) { benchmarkIndent(examples[6].compact, b) }
+func BenchmarkIndentExample7b(b *testing.B) {
+	benchmarkIndent(strings.Repeat(examples[6].compact, 100), b)
 }
 
 func TestIndent(t *testing.T) {

--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -175,9 +175,10 @@ func nonSpace(b []byte) bool {
 
 // An Encoder writes JSON values to an output stream.
 type Encoder struct {
-	w          io.Writer
-	err        error
-	escapeHTML bool
+	w           io.Writer
+	err         error
+	escapeHTML  bool
+	directWrite bool
 
 	indentBuf    *bytes.Buffer
 	indentPrefix string
@@ -210,9 +211,16 @@ func (enc *Encoder) Encode(v interface{}) error {
 	// is required if the encoded value was a number,
 	// so that the reader knows there aren't more
 	// digits coming.
-	e.WriteByte('\n')
+	err = e.WriteByte('\n')
+	if enc.directWrite {
+		encodeStatePool.Put(e)
+		return err
+	}
 
 	b := e.Bytes()
+	if iw, ok := enc.w.(*indentWriter); ok {
+		iw.scan.reset()
+	}
 	if enc.indentPrefix != "" || enc.indentValue != "" {
 		if enc.indentBuf == nil {
 			enc.indentBuf = new(bytes.Buffer)
@@ -231,12 +239,31 @@ func (enc *Encoder) Encode(v interface{}) error {
 	return err
 }
 
+// SetDirectWrite instructs the Encoder that it may write directly to the
+// underlying io.Writer, without first checking for errors. This can improve
+// performance in some cases, but has the potential to produce partial or
+// invalid JSON output in the case of errors.
+func (enc *Encoder) SetDirectWrite() {
+	enc.directWrite = true
+}
+
 // SetIndent instructs the encoder to format each subsequent encoded
 // value as if indented by the package-level function Indent(dst, src, prefix, indent).
 // Calling SetIndent("", "") disables indentation.
 func (enc *Encoder) SetIndent(prefix, indent string) {
-	enc.indentPrefix = prefix
-	enc.indentValue = indent
+	if !enc.directWrite {
+		enc.indentPrefix = prefix
+		enc.indentValue = indent
+		return
+	}
+	w := enc.w
+	if iw, ok := enc.w.(*indentWriter); ok {
+		w = iw.dst
+	}
+	if prefix != "" || indent != "" {
+		w = IndentWriter(w, prefix, indent)
+	}
+	enc.w = w
 }
 
 // SetEscapeHTML specifies whether problematic HTML characters

--- a/src/encoding/json/stream.go
+++ b/src/encoding/json/stream.go
@@ -505,3 +505,21 @@ func (dec *Decoder) peek() (byte, error) {
 func (dec *Decoder) offset() int64 {
 	return dec.scanned + int64(dec.scanp)
 }
+
+type writer interface {
+	Write([]byte) (int, error)
+	WriteString(string) (int, error)
+	WriteByte(byte) error
+}
+
+type convertWriter struct {
+	io.Writer
+}
+
+func (c convertWriter) WriteString(s string) (int, error) {
+	return io.WriteString(c, s)
+}
+func (c convertWriter) WriteByte(b byte) error {
+	_, err := c.Write([]byte{b})
+	return err
+}


### PR DESCRIPTION
This PR is a POC for using the `IndentWriter` implementation in #1 to indent when using the `json.Encoder.SetIndent`, in addition to the new `json.Encoder.SetDirectWrite`, along with benchmarks to compare the before and after.

Before:

    BenchmarkMarshalAndIndentStream_Int-4            3000000               578 ns/op             176 B/op          3 allocs/op
    BenchmarkMarshalAndIndentStream_Optionals-4       500000              3265 ns/op             344 B/op          6 allocs/op
    BenchmarkMarshalAndIndentStream_StringTag-4       500000              2660 ns/op             336 B/op          6 allocs/op

After:

    BenchmarkMarshalAndIndentStream_Int-4            5000000               307 ns/op             224 B/op          3 allocs/op
    BenchmarkMarshalAndIndentStream_Optionals-4      2000000               798 ns/op             224 B/op          3 allocs/op
    BenchmarkMarshalAndIndentStream_StringTag-4      2000000               739 ns/op             232 B/op          4 allocs/op

So no improvement (and a slight memory hit) for really small values (a single int), but a clear improvement, both in terms of execution time, and memory usage/allocations, when using encoding and indenting structs.